### PR TITLE
Reduce redundancy in Card.hs

### DIFF
--- a/src/Card.hs
+++ b/src/Card.hs
@@ -16,21 +16,12 @@ instance Show Suit where
 data Rank =
   Two | Three | Four | Five | Six | Seven | Eight | Nine | Ten | Jack | Queen | King | Ace
   deriving (Eq, Ord, Enum, Bounded)
--- not sure if can define as "int in range 2..10 or J,Q,K,A". for now, brute force
 instance Show Rank where
-  show Two   = "2"
-  show Three = "3"
-  show Four  = "4"
-  show Five  = "5"
-  show Six   = "6"
-  show Seven = "7"
-  show Eight = "8"
-  show Nine  = "9"
-  show Ten   = "10"
   show Jack  = "J"
   show Queen = "Q"
   show King  = "K"
   show Ace   = "A"
+  show r     = show $ fromEnum r + 2 -- Two = "2", Three = "3", etc
 
 -- a Card is a combination of Rank and Suit
 -- the accessor functions rank and suit will be useful, so the syntax below will be used instead of just
@@ -43,19 +34,10 @@ instance Show Card where
   show (Card r s) =
     let
       rmod = case r of
-        Two   ->  2
-        Three ->  3
-        Four  ->  4
-        Five  ->  5
-        Six   ->  6
-        Seven ->  7
-        Eight ->  8
-        Nine  ->  9
-        Ten   -> 10
-        Jack  -> 11
         Queen -> 13  -- 12 is the Knave -- not used in the typical French deck
         King  -> 14
         Ace   ->  1
+        _     -> fromEnum r + 2 -- assign Two = 2, Three = 3, etc
       smod = case s of
         Club    ->  3*16
         Diamond ->  2*16


### PR DESCRIPTION
Use fromEnum to automatically convert Ranks into Ints, thus decreasing
the redundancy in typing out Two = "2", 2, etc.

I just ran across the fromEnum function and thought of our conversation from a while ago about this, and thought I would submit the PR. Hope that's cool!